### PR TITLE
Testing Rig to reproduce dynamic includes error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.venv
+*~
+.vagrant

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+---
+language: python
+python: "2.7"
+
+env:
+  - NVM_ENV=system
+  - NVM_ENV=user
+
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq git
+install:
+  - pip install ansible==1.8.4
+script:
+  - echo localhost > inventory
+  - ansible-playbook -i inventory test.yml --syntax-check
+  - ansible-playbook -i inventory test.yml --connection=local --sudo -e "nvm_env=$NVM_ENV"
+  - >
+    ansible-playbook -i inventory test.yml --connection=local --sudo -e "nvm_env=$NVM_ENV"
+    | grep -q 'changed=0.*failed=0'
+    && (echo 'Idempotence test: pass' && exit 0)
+    || (echo 'Idempotence test: fail' && exit 1)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,13 @@
+Vagrant.configure('2') do |config|
+  config.vm.define 'pablocrivella' do |c|
+    c.vm.box = 'ubuntu/trusty64'
+    c.vm.network :private_network, ip: '192.168.40.2'
+    c.vm.hostname = 'pablocrivella.local'
+    c.vm.provision 'ansible' do |ansible|
+      ansible.playbook = 'test.yml'
+      ansible.sudo = true
+      ansible.inventory_path = 'vagrant-inventory'
+      ansible.host_key_checking = false
+    end
+  end
+end

--- a/test.yml
+++ b/test.yml
@@ -1,0 +1,11 @@
+- hosts: all
+  vars_files:
+    - defaults/main.yml
+    - vars/main.yml
+    - vars/test.yml
+  pre_tasks:
+    - apt: name=git state=installed
+  tasks:
+    - include: tasks/main.yml
+  handlers:
+    - include: handlers/main.yml

--- a/vagrant-inventory
+++ b/vagrant-inventory
@@ -1,0 +1,2 @@
+[pablocrivella]
+pablocrivella.local ansible_ssh_host=192.168.40.2 ansible_ssh_port=22

--- a/vars/test.yml
+++ b/vars/test.yml
@@ -1,5 +1,4 @@
 nvm_default_node_version: v0.12.7
-nvm_env: system
 nvm_version: v0.25.4
 nvm_node_versions:
   - v0.12.7

--- a/vars/test.yml
+++ b/vars/test.yml
@@ -1,0 +1,7 @@
+nvm_default_node_version: v0.12.7
+nvm_env: system
+nvm_version: v0.25.4
+nvm_node_versions:
+  - v0.12.7
+  - v0.10.36
+nvm_global_packages:: []


### PR DESCRIPTION
@pablocrivella the error I am getting with dynamic includes _should_ be reproducible in this branch..

```
sudo apt-get install virtualbox
wget https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.4_x86_64.deb
sudo dpkg -i vagrant_1.7.4_x86_64.deb
sudo pip install ansible==1.9.2

vagrant up
```
You _should_ see the following:

```
==> pablocrivella: Running provisioner: ansible...
ERROR: file could not read: /path/to/your/ansible-role-nvm/tasks/system/{{ item }}.yml
Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```

Ive also added in all the necessary tools for development and travis testing :)  

please let me know if you are able to reproduce the error. Ta

Ive also got travis reproducing the error, see https://travis-ci.org/farridav/ansible-role-nvm/builds/76843319