### PR TITLE
compatibility with non-bash shells

### DIFF
--- a/tasks/system/install_packages.yml
+++ b/tasks/system/install_packages.yml
@@ -2,5 +2,5 @@
 - name: install packages
   shell: bash -lc "nvm use {{ item.0 }} && npm install -g {{ item.1 }}"
   with_nested:
-    - nvm_node_versions
-    - nvm_global_packages
+    - "{{ nvm_node_versions }}"
+    - "{{ nvm_global_packages }}"

--- a/tasks/system/install_versions.yml
+++ b/tasks/system/install_versions.yml
@@ -3,7 +3,7 @@
   shell: bash -lc "nvm install {{ item }}"
   register: output
   changed_when: "'already installed.' not in output.stderr"
-  with_items: nvm_node_versions
+  with_items: "{{ nvm_node_versions }}"
 
 - name: create alias directory
   file: path="{{ nvm_root }}/alias" state=directory

--- a/tasks/user/install_packages.yml
+++ b/tasks/user/install_packages.yml
@@ -4,6 +4,6 @@
   become: true
   become_user: "{{ item.0 }}"
   with_nested:
-    - nvm_users
-    - nvm_node_versions
-    - nvm_global_packages
+    - "{{ nvm_users }}"
+    - "{{ nvm_node_versions }}"
+    - "{{ nvm_global_packages }}"

--- a/tasks/user/install_versions.yml
+++ b/tasks/user/install_versions.yml
@@ -13,7 +13,7 @@
   file: path="{{ nvm_root }}/alias" state=directory
   become: true
   become_user: "{{ item }}"
-  with_items: nvm_users
+  with_items: "{{ nvm_users }}"
 
 - name: set {{ nvm_default_node_version }} as default version for each user
   copy: dest="{{ nvm_root }}/alias/default" content="{{ nvm_default_node_version }}"

--- a/templates/nvm.sh.j2
+++ b/templates/nvm.sh.j2
@@ -1,7 +1,9 @@
+export NVM_DIR="{{ nvm_root }}"
+
 {% if nvm_env == 'system' %}
-source {{ nvm_root }}/nvm.sh
+. {{ nvm_root }}/nvm.sh
 {% else %}
 if [ -d "$HOME/.nvm" ]; then
-  source {{ nvm_root }}/nvm.sh
+  . {{ nvm_root }}/nvm.sh
 fi
 {% endif %}


### PR DESCRIPTION
- use `.` instead of `source` for sourcing the shell script
- fix a few deprecation-related notices
- export `NVM_DIR`to the environment with what we specify in `nvm_root` so that one can utilize it in scripts (if there was an `nvm which` command like rbenv's, this wouldn't have been necessary. I needed this to locate specific binaries)