### PR TITLE
Use $HOME instead of ~ in user var file

### DIFF
--- a/vars/user.yml
+++ b/vars/user.yml
@@ -1,2 +1,2 @@
 ---
-nvm_root: "~/.nvm"
+nvm_root: "$HOME/.nvm"


### PR DESCRIPTION
variables from my playbook:
```yml
    nvm_env: user
    nvm_version: v0.33.11
    nvm_default_node_version: v11.0.0
    nvm_node_versions:
      - v11.0.0
    nvm_users:
      - deployer
```

While installing nvm for user I ended up with a `~/~/.nvm/` path.
Using `$HOME` env var solves the problem.